### PR TITLE
LPS-75369 Using UTF-8 for zip file name encoding

### DIFF
--- a/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DownloadEntriesMVCResourceCommand.java
+++ b/modules/apps/collaboration/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/DownloadEntriesMVCResourceCommand.java
@@ -236,10 +236,9 @@ public class DownloadEntriesMVCResourceCommand implements MVCResourceCommand {
 			FileEntry fileEntry, String path, ZipWriter zipWriter)
 		throws Exception {
 
-		String fileName = _sanitizeName(fileEntry.getFileName());
-
 		zipWriter.addEntry(
-			path + StringPool.SLASH + fileName, fileEntry.getContentStream());
+			path + StringPool.SLASH + fileEntry.getFileName(),
+			fileEntry.getContentStream());
 	}
 
 	protected void zipFolder(
@@ -255,11 +254,9 @@ public class DownloadEntriesMVCResourceCommand implements MVCResourceCommand {
 			if (entry instanceof Folder) {
 				Folder folder = (Folder)entry;
 
-				String folderName = _sanitizeName(folder.getName());
-
 				zipFolder(
 					folder.getRepositoryId(), folder.getFolderId(),
-					path.concat(StringPool.SLASH).concat(folderName),
+					path.concat(StringPool.SLASH).concat(folder.getName()),
 					zipWriter);
 			}
 			else if (entry instanceof FileEntry) {
@@ -274,17 +271,6 @@ public class DownloadEntriesMVCResourceCommand implements MVCResourceCommand {
 				zipFileEntry(fileEntry, path, zipWriter);
 			}
 		}
-	}
-
-	private String _sanitizeName(String name) {
-		CharsetEncoder charsetEncoder = CharsetEncoderUtil.getCharsetEncoder(
-			"US-ASCII");
-
-		if (!charsetEncoder.canEncode(name)) {
-			name = HtmlUtil.escapeURL(name);
-		}
-
-		return name;
 	}
 
 	private DLAppService _dlAppService;

--- a/portal-impl/src/com/liferay/portal/zip/ZipReaderImpl.java
+++ b/portal-impl/src/com/liferay/portal/zip/ZipReaderImpl.java
@@ -206,7 +206,7 @@ public class ZipReaderImpl implements ZipReader {
 		File.setDefaultArchiveDetector(
 			new DefaultArchiveDetector(
 				ArchiveDetector.ALL, "lar|" + ArchiveDetector.ALL.getSuffixes(),
-				new ZipDriver()));
+				new ZipDriver("UTF-8")));
 
 		TrueZIPHelperUtil.initialize();
 	}

--- a/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
+++ b/portal-impl/src/com/liferay/portal/zip/ZipWriterImpl.java
@@ -142,7 +142,7 @@ public class ZipWriterImpl implements ZipWriter {
 		File.setDefaultArchiveDetector(
 			new DefaultArchiveDetector(
 				ArchiveDetector.ALL, "lar|" + ArchiveDetector.ALL.getSuffixes(),
-				new ZipDriver()));
+				new ZipDriver("UTF-8")));
 
 		TrueZIPHelperUtil.initialize();
 	}


### PR DESCRIPTION
Hi @austinchiang, 

I am sending this to you so that you guys can verify every use of zip files in the portal is not broken by these changes (staging, documenta library, liferay sync...).

This is what I have tested on OSX:

* ZIP files can be downloaded from the document library:
   - ✅  with `UTF-8` characters (Japanese).
   - ✅  with standard english characters.
* LAR files can be exported / imported:
   - ✅  generated with the old code (Using the default `IBM437` charset).
   - ✅  generated with the new code (Using `UTF-8`).

To test the document library:
1.  Add a few files with Japanese names e.g.
2.  Select them all.
3. Click download.

A ZIP file will be downloaded containing all of them. With this fix the names should remain the same with whichever characters you used in the first place.

Please let me know if you need any help.

