### PR TITLE
LPS-102965 Add markup / styles to fit the design

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -371,9 +371,21 @@ body {
 			}
 
 			.category-name,
-			.user-name,
-			.site-name {
+			.depot-type,
+			.site-name,
+			.user-name {
 				color: $product-menu-panel-title-color;
+			}
+
+			.depot-type,
+			.site-name {
+				line-height: 1.25;
+			}
+
+			.depot-type {
+				font-size: 0.75rem;
+				font-weight: normal;
+				text-transform: uppercase;
 			}
 		}
 	}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -38,6 +38,7 @@ page import="com.liferay.portal.kernel.exception.SystemException" %><%@
 page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
+page import="com.liferay.portal.kernel.model.GroupConstants" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -84,13 +84,18 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 				</c:otherwise>
 			</c:choose>
 
-			<span class="site-name text-truncate">
-				<%= HtmlUtil.escape(siteAdministrationPanelCategoryDisplayContext.getGroupName()) %>
+			<div class="autofit-col">
+				<span class="text-uppercase">
+					<liferay-ui:message key='<%= (group.getType() == GroupConstants.TYPE_DEPOT) ? "repository" : "site" %>' />
+				</span>
+				<span class="site-name text-truncate">
+					<%= HtmlUtil.escape(siteAdministrationPanelCategoryDisplayContext.getGroupName()) %>
 
-				<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() && !group.isStagedRemotely() %>">
-					<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
-				</c:if>
-			</span>
+					<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() && !group.isStagedRemotely() %>">
+						<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
+					</c:if>
+				</span>
+			</div>
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">
 				<span class="panel-notifications-count sticker sticker-right sticker-rounded sticker-sm sticker-warning"><%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() %></span>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -26,12 +26,12 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 <c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowSiteSelector() %>">
 	<div class="icon-sites">
 		<liferay-ui:icon
-			icon="sites"
+			icon="change"
 			id="manageSitesLink"
 			label="<%= false %>"
 			linkCssClass="icon-monospaced"
 			markupView="lexicon"
-			message="go-to-other-site"
+			message="go-to-other-space"
 			url="javascript:;"
 		/>
 	</div>
@@ -59,7 +59,7 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 					},
 					eventName: '<%= eventName %>',
 					id: '<portlet:namespace />selectSite',
-					title: '<liferay-ui:message key="select-site" />',
+					title: '<liferay-ui:message key="select-space" />',
 					uri: '<%= itemSelectorURL.toString() %>'
 				},
 				function(event) {
@@ -104,7 +104,7 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 	<c:when test="<%= siteAdministrationPanelCategoryDisplayContext.isShowSiteSelector() %>">
 		<div class="collapsed panel-toggler">
 			<span class="site-name">
-				<liferay-ui:message key="choose-a-site" />
+				<liferay-ui:message key="choose-a-space" />
 			</span>
 		</div>
 	</c:when>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header.jsp
@@ -73,28 +73,33 @@ PanelCategory panelCategory = siteAdministrationPanelCategoryDisplayContext.getP
 <c:choose>
 	<c:when test="<%= group != null %>">
 		<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelCategory.getKey()) %>Collapse" aria-expanded="<%= siteAdministrationPanelCategoryDisplayContext.isCollapsedPanel() %>" class="panel-toggler <%= (group != null) ? "collapse-icon collapse-icon-middle " : StringPool.BLANK %> <%= siteAdministrationPanelCategoryDisplayContext.isCollapsedPanel() ? StringPool.BLANK : "collapsed" %> site-administration-toggler" data-parent="#<portlet:namespace />Accordion" data-qa-id="productMenuSiteAdministrationPanelCategory" data-toggle="collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelCategory.getKey()) %>Collapse" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelCategory.getKey()) %>Toggler" <%= (group != null) ? "role=\"button\"" : StringPool.BLANK %>>
-			<c:choose>
-				<c:when test="<%= Validator.isNotNull(siteAdministrationPanelCategoryDisplayContext.getLogoURL()) %>">
-					<div class="aspect-ratio-bg-cover sticker" style="background-image: url(<%= siteAdministrationPanelCategoryDisplayContext.getLogoURL() %>);"></div>
-				</c:when>
-				<c:otherwise>
-					<div class="sticker sticker-default">
-						<aui:icon image="<%= group.getIconCssClass() %>" markupView="lexicon" />
+			<div class="autofit-row autofit-row-center">
+				<div class="autofit-col">
+					<c:choose>
+						<c:when test="<%= Validator.isNotNull(siteAdministrationPanelCategoryDisplayContext.getLogoURL()) %>">
+							<div class="aspect-ratio-bg-cover sticker" style="background-image: url(<%= siteAdministrationPanelCategoryDisplayContext.getLogoURL() %>);"></div>
+						</c:when>
+						<c:otherwise>
+							<div class="sticker sticker-default">
+								<aui:icon image="<%= group.getIconCssClass() %>" markupView="lexicon" />
+							</div>
+						</c:otherwise>
+					</c:choose>
+				</div>
+
+				<div class="autofit-col autofit-col-expand">
+					<div class="depot-type">
+						<liferay-ui:message key='<%= (group.getType() == GroupConstants.TYPE_DEPOT) ? "repository" : "site" %>' />
 					</div>
-				</c:otherwise>
-			</c:choose>
 
-			<div class="autofit-col">
-				<span class="text-uppercase">
-					<liferay-ui:message key='<%= (group.getType() == GroupConstants.TYPE_DEPOT) ? "repository" : "site" %>' />
-				</span>
-				<span class="site-name text-truncate">
-					<%= HtmlUtil.escape(siteAdministrationPanelCategoryDisplayContext.getGroupName()) %>
+					<div class="site-name text-truncate">
+						<%= HtmlUtil.escape(siteAdministrationPanelCategoryDisplayContext.getGroupName()) %>
 
-					<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() && !group.isStagedRemotely() %>">
-						<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
-					</c:if>
-				</span>
+						<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowStagingInfo() && !group.isStagedRemotely() %>">
+							<span class="site-sub-name"> - <liferay-ui:message key="<%= siteAdministrationPanelCategoryDisplayContext.getStagingLabel() %>" /></span>
+						</c:if>
+					</div>
+				</div>
 			</div>
 
 			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.getNotificationsCount() > 0 %>">

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site
-go-to-other-site=Go to Other Site
+choose-a-space=Choose a Space
+go-to-other-space=Go to Other Space
 go-to-site=Go to Site
 manage-sites=Manage Sites
+select-space=Select Space
 x-site={0}'s Site

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ar.properties
@@ -1,5 +1,6 @@
-choose-a-site=اختيار موقع
-go-to-other-site=الانتقال إلى موقع آخر
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=الانتقال إلى الموقع
 manage-sites=إدارة المواقع
+select-space=Select Space (Automatic Copy)
 x-site=موقع {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_bg.properties
@@ -1,5 +1,6 @@
-choose-a-site=Изберете сайт (Automatic Translation)
-go-to-other-site=Отидете на друг сайт (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Отидете на сайта (Automatic Translation)
 manage-sites=Управление на сайтове (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ca.properties
@@ -1,5 +1,6 @@
-choose-a-site=Seleccioneu un lloc
-go-to-other-site=Anar a un altre lloc web
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Anar al lloc web
 manage-sites=Gestionar llocs webs
+select-space=Select Space (Automatic Copy)
 x-site=Lloc de {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_cs.properties
@@ -1,5 +1,6 @@
-choose-a-site=Zvolte Web (Automatic Translation)
-go-to-other-site=Přejít na jiné stránky (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Přejít na web (Automatic Translation)
 manage-sites=Spravovat weby (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_da.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_da.properties
@@ -1,5 +1,6 @@
-choose-a-site=Vælg et websted (Automatic Translation)
-go-to-other-site=Gå til anden side (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Gå til webstedet (Automatic Translation)
 manage-sites=Administrere websteder (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_de.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_de.properties
@@ -1,5 +1,6 @@
-choose-a-site=Eine Site wählen
-go-to-other-site=Zu anderer Site wechseln
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Zu Site wechseln
 manage-sites=Sites verwalten
+select-space=Select Space (Automatic Copy)
 x-site=Site von {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_el.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_el.properties
@@ -1,5 +1,6 @@
-choose-a-site=Επιλέξτε μια τοποθεσία (Automatic Translation)
-go-to-other-site=Μεταβείτε σε άλλη τοποθεσία (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Μεταβείτε στην τοποθεσία (Automatic Translation)
 manage-sites=Διαχειριστείτε τοποθεσίες (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_en.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_en.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site
-go-to-other-site=Go to Other Site
+choose-a-space=Choose a Space
+go-to-other-space=Go to Other Space
 go-to-site=Go to Site
 manage-sites=Manage Sites
+select-space=Select Space
 x-site={0}'s Site

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_es.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_es.properties
@@ -1,5 +1,6 @@
-choose-a-site=Elija un sitio
-go-to-other-site=Ir a otro sitio
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Ir al sitio
 manage-sites=Administrar Sitios
+select-space=Select Space (Automatic Copy)
 x-site=Sitio de {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_et.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_et.properties
@@ -1,5 +1,6 @@
-choose-a-site=Valige esmalt sait (Automatic Translation)
-go-to-other-site=Lähen muu saidil (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Mine saidi (Automatic Translation)
 manage-sites=Saitide haldamine (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_eu.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_fa.properties
@@ -1,5 +1,6 @@
-choose-a-site=انتخاب سایت
-go-to-other-site=به سایت دیگری بروید
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=به سایت بروید
 manage-sites=سایت‌‌ها را مدیریت کنید
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Siteinclude-inherited-permissions-help=برای شامل کردن کاربرانی که مجوز جستجو را دارند، این را تنظیم نمایید.کاربر نقش‌ها از کاربران گروه و عضویت سازمان‌ها می‌گیرد.

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_fi.properties
@@ -1,5 +1,6 @@
-choose-a-site=Valitse sivusto
-go-to-other-site=Mene toiselle sivustolle
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Mene sivustolle
 manage-sites=Hallitse sivustoja
+select-space=Select Space (Automatic Copy)
 x-site={0}:n sivusto

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_fr.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choisir un site
-go-to-other-site=Aller à un autre site
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Aller au site
 manage-sites=Gérer sites
+select-space=Select Space (Automatic Copy)
 x-site=Site de {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_gl.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_hi_IN.properties
@@ -1,5 +1,6 @@
-choose-a-site=एक साइट का चयन (Automatic Translation)
-go-to-other-site=अन्य साइट पर जाएँ (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=साइट पर जाएँ (Automatic Translation)
 manage-sites=साइट्स प्रबंधित करें (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_hr.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_hu.properties
@@ -1,5 +1,6 @@
-choose-a-site=Válasszon helyszínt
-go-to-other-site=Menj egy másik webhelyre
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Menj erre a webhelyre
 manage-sites=Webhelyek kezelése
+select-space=Select Space (Automatic Copy)
 x-site={0} oldala

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_in.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_in.properties
@@ -1,5 +1,6 @@
-choose-a-site=Pilih situs (Automatic Translation)
-go-to-other-site=Pergi ke situs lainnya (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Pergi ke situs (Automatic Translation)
 manage-sites=Mengelola situs (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_it.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_it.properties
@@ -1,5 +1,6 @@
-choose-a-site=Scegli un sito
-go-to-other-site=Vai ad un altro sito
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Vai al sito
 manage-sites=Gestione siti
+select-space=Select Space (Automatic Copy)
 x-site=Sito di {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_iw.properties
@@ -1,5 +1,6 @@
-choose-a-site=בחר אתר
-go-to-other-site=עבור לאתר אחר
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=עבור לאתר
 manage-sites=נהל אתרים
+select-space=Select Space (Automatic Copy)
 x-site=האתר של {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ja.properties
@@ -1,5 +1,6 @@
-choose-a-site=サイトを選択してください
-go-to-other-site=他のサイトへ移動
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=サイトへ移動
 manage-sites=サイトの管理
+select-space=Select Space (Automatic Copy)
 x-site={0}のサイト

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_kk.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ko.properties
@@ -1,5 +1,6 @@
-choose-a-site=사이트 선택 (Automatic Translation)
-go-to-other-site=다른 사이트에가 서 (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=사이트에가 서 (Automatic Translation)
 manage-sites=사이트 관리 (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_lo.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_lt.properties
@@ -1,5 +1,6 @@
-choose-a-site=Pasirinkti svetainę (Automatic Translation)
-go-to-other-site=Eikite į kitą svetainę (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Eikite į svetainę (Automatic Translation)
 manage-sites=Tvarkykite svetaines (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_nb.properties
@@ -1,5 +1,6 @@
-choose-a-site=Velg et område (Automatic Translation)
-go-to-other-site=Gå til andre nettsted (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Gå til webområdet (Automatic Translation)
 manage-sites=Administrere områder (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_nl.properties
@@ -1,5 +1,6 @@
-choose-a-site=Kies een site
-go-to-other-site=Ga naar andere site
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Ga naar site
 manage-sites=Beheer sites
+select-space=Select Space (Automatic Copy)
 x-site={0}'s site

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_nl_BE.properties
@@ -1,5 +1,6 @@
-choose-a-site=Kies een Site (Automatic Translation)
-go-to-other-site=Ga naar de andere Site (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Ga naar Site (Automatic Translation)
 manage-sites=Sites beheren (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_pl.properties
@@ -1,5 +1,6 @@
-choose-a-site=Wybierz witrynę (Automatic Translation)
-go-to-other-site=Przejdź do innej strony (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Przejdź do witryny (Automatic Translation)
 manage-sites=Zarządzanie witrynami (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_pt_BR.properties
@@ -1,5 +1,6 @@
-choose-a-site=Escolha um site
-go-to-other-site=Ir para Outro Site
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Ir para o Site
 manage-sites=Gerenciar Sites
+select-space=Select Space (Automatic Copy)
 x-site=Site de {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_pt_PT.properties
@@ -1,5 +1,6 @@
-choose-a-site=Escolha um site
-go-to-other-site=Ir para Outro Site
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Ir para Site
 manage-sites=Gerir Sites
+select-space=Select Space (Automatic Copy)
 x-site=Site de {0}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ro.properties
@@ -1,5 +1,6 @@
-choose-a-site=Alege un Site (Automatic Translation)
-go-to-other-site=Du-te la alt Site (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Du-te la site-ul (Automatic Translation)
 manage-sites=Gestiona site-uri (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ru.properties
@@ -1,5 +1,6 @@
-choose-a-site=Выбрать сайт (Automatic Translation)
-go-to-other-site=Перейти на другой сайт (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Перейти на сайт (Automatic Translation)
 manage-sites=Управление сайтами (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sk.properties
@@ -1,5 +1,6 @@
-choose-a-site=Vyberte lokalitu (Automatic Translation)
-go-to-other-site=Ísť na ďalšie sídlo
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Ísť na sídlo
 manage-sites=Spravovať sídla
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sl.properties
@@ -1,5 +1,6 @@
-choose-a-site=Izberite mesto (Automatic Translation)
-go-to-other-site=Pojdite na drugo stran (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Pojdi na stran (Automatic Translation)
 manage-sites=Upravljanju območij (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sr_RS.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,5 +1,6 @@
-choose-a-site=Choose a Site (Automatic Copy)
-go-to-other-site=Go to Other Site (Automatic Copy)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Go to Site (Automatic Copy)
 manage-sites=Manage Sites (Automatic Copy)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_sv.properties
@@ -1,5 +1,6 @@
-choose-a-site=Välj en webbplats
-go-to-other-site=Gå till annan webbplats
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Gå till webbplats
 manage-sites=Hantera webbplatser
+select-space=Select Space (Automatic Copy)
 x-site={0}s webbplats

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_ta_IN.properties
@@ -1,5 +1,6 @@
-choose-a-site=ஒரு தளத்தைத் தேர்வு செய்க
-go-to-other-site=பிற தளத்திற்குச் செல்
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=தளத்திற்குச் செல்
 manage-sites=தளங்களை நிர்வகி
+select-space=Select Space (Automatic Copy)
 x-site={0} உடைய தளம்

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_th.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_th.properties
@@ -1,5 +1,6 @@
-choose-a-site=เลือกไซต์ (Automatic Translation)
-go-to-other-site=ไปยังไซต์อื่น ๆ (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=ไปที่เว็บไซต์ (Automatic Translation)
 manage-sites=จัดการไซต์ (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_tr.properties
@@ -1,5 +1,6 @@
-choose-a-site=Bir yeri tercih ediyor. (Automatic Translation)
-go-to-other-site=Diğer siteye gidin (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Sitesine gidin (Automatic Translation)
 manage-sites=Siteleri Yönet (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_uk.properties
@@ -1,5 +1,6 @@
-choose-a-site=Виберіть сайт (Automatic Translation)
-go-to-other-site=Перейдіть на інший сайт (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Зайдіть на сайт (Automatic Translation)
 manage-sites=Керування сайтами (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_vi.properties
@@ -1,5 +1,6 @@
-choose-a-site=Chọn một trang web (Automatic Translation)
-go-to-other-site=Đi đến trang web khác (Automatic Translation)
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=Đi đến trang web (Automatic Translation)
 manage-sites=Quản lý các trang web (Automatic Translation)
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_zh_CN.properties
@@ -1,5 +1,6 @@
-choose-a-site=选择一个站点
-go-to-other-site=访问其他站点
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=访问站点
 manage-sites=管理站点
+select-space=Select Space (Automatic Copy)
 x-site={0}的站点

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/content/Language_zh_TW.properties
@@ -1,5 +1,6 @@
-choose-a-site=選擇一個網站 (Automatic Translation)
-go-to-other-site=到其他站台
+choose-a-space=Choose a Space (Automatic Copy)
+go-to-other-space=Go to Other Space (Automatic Copy)
 go-to-site=到站台
 manage-sites=管理站台
+select-space=Select Space (Automatic Copy)
 x-site={0}'s Site (Automatic Copy)


### PR DESCRIPTION
Hey @austinchiang !

We've made the following changes to the site navigation:
- Changed the icon from "site" to "change"
- Added the kind of group ("site" or "repository") on top of the group name.

In the ticket there's a link to a Figma design where you can see how this is supposed to look like (the design includes quite a lot more than the site navigation).

This will probably break some Poshi tests, as the markup is different and some literals have changed as well ("Go to Site" -> "Go to Space"). Let me know if you need anything here.

Thanks!