### PR TITLE
LPS-105051 layout cannot be null

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -43,7 +43,11 @@ if (Validator.isNotNull(backURL)) {
 }
 
 renderResponse.setTitle(selLayout.getName(locale));
+
+String portletResource = ParamUtil.getString(request, "portletResource");
 %>
+
+<liferay-ui:success key='<%= portletResource + "layoutUpdated" %>' message='<%= LanguageUtil.get(resourceBundle, "the-page-was-updated-succesfully") %>' />
 
 <liferay-frontend:screen-navigation
 	containerCssClass="col-lg-8"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
@@ -85,7 +85,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 					if (enableLayoutButton) {
 						enableLayoutButton.addEventListener('click', function(event) {
 							<portlet:actionURL name="/layout/enable_layout" var="enableLayoutURL">
-								<portlet:param name="redirect" value="<%= redirectURL.toString() %>" />
+								<portlet:param name="redirect" value="<%= currentURL %>" />
 								<portlet:param name="incompleteLayoutRevisionId" value="<%= String.valueOf(layoutRevision.getLayoutRevisionId()) %>" />
 							</portlet:actionURL>
 
@@ -100,7 +100,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 					if (deleteLayoutButton) {
 						deleteLayoutButton.addEventListener('click', function(event) {
 							<portlet:actionURL name="/layout/delete_layout" var="deleteLayoutURL">
-								<portlet:param name="redirect" value='<%= HttpUtil.addParameter(redirectURL.toString(), liferayPortletResponse.getNamespace() + "selPlid", selLayout.getParentPlid()) %>' />
+								<portlet:param name="redirect" value="<%= currentURL %>" />
 								<portlet:param name="selPlid" value="<%= String.valueOf(layoutsAdminDisplayContext.getSelPlid()) %>" />
 								<portlet:param name="layoutSetBranchId" value="0" />
 								<portlet:param name="selPlid" value="<%= String.valueOf(selLayout.getParentPlid()) %>" />
@@ -119,7 +119,7 @@ renderResponse.setTitle(selLayout.getName(locale));
 		</portlet:actionURL>
 
 		<aui:form action='<%= HttpUtil.addParameter(editLayoutURL, "refererPlid", plid) %>' enctype="multipart/form-data" method="post" name="editLayoutFm" onSubmit="event.preventDefault();">
-			<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 			<aui:input name="backURL" type="hidden" value="<%= backURL %>" />
 			<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
 			<aui:input name="groupId" type="hidden" value="<%= layoutsAdminDisplayContext.getGroupId() %>" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
@@ -33,8 +33,6 @@ Group group = layoutsAdminDisplayContext.getGroup();
 
 Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
 
-PortletURL redirectURL = layoutsAdminDisplayContext.getRedirectURL();
-
 LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(selLayout);
 
 String layoutSetBranchName = StringPool.BLANK;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
@@ -32,6 +32,7 @@ Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
 
 <aui:form action="<%= editOpenGraphURL %>" method="post" name="fm">
 	<aui:input name="portletResource" type="hidden" value='<%= ParamUtil.getString(request, "portletResource") %>' />
+	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 	<aui:input name="groupId" type="hidden" value="<%= layoutsAdminDisplayContext.getGroupId() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= layoutsAdminDisplayContext.isPrivateLayout() %>" />
 	<aui:input name="layoutId" type="hidden" value="<%= layoutsAdminDisplayContext.getLayoutId() %>" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -59,12 +59,12 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 
 				<liferay-asset:asset-categories-selector
 					className="<%= Layout.class.getName() %>"
-					classPK="<%= (selLayout != null) ? selLayout.getPrimaryKey() : 0 %>"
+					classPK="<%= selLayout.getPrimaryKey() %>"
 				/>
 
 				<liferay-asset:asset-tags-selector
 					className="<%= Layout.class.getName() %>"
-					classPK="<%= (selLayout != null) ? selLayout.getPrimaryKey() : 0 %>"
+					classPK="<%= selLayout.getPrimaryKey() %>"
 				/>
 
 				<aui:input id="title" label="html-title" name="title" placeholder="title" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -34,6 +34,7 @@ UnicodeProperties layoutTypeSettings = selLayout.getTypeSettingsProperties();
 
 <aui:form action="<%= editSEOURL %>" method="post" name="fm">
 	<aui:input name="portletResource" type="hidden" value='<%= ParamUtil.getString(request, "portletResource") %>' />
+	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
 	<aui:input name="groupId" type="hidden" value="<%= layoutsAdminDisplayContext.getGroupId() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= layoutsAdminDisplayContext.isPrivateLayout() %>" />
 	<aui:input name="layoutId" type="hidden" value="<%= layoutsAdminDisplayContext.getLayoutId() %>" />


### PR DESCRIPTION
Hey @austinchiang 

This PR caused a lot of CI failures in master. The problem is that we've changed the redirects in the layout edit page; now it will keep the user in the same page to simplify editions over multiple tabs.

/cc @kyle-miho